### PR TITLE
Fix telegram bot updater initialization error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -47,20 +47,29 @@ class BrainDumpBot:
         # אחסון זמני של מחשבות במצב dump
         self.dump_sessions = {}
     
-    async def setup(self):
+    async def setup(self, use_updater: bool = False):
         """
-        הגדרת הבוט והתחברות לשירותים
+        הגדרת הבוט והתחברות לשירותים.
+
+        Args:
+            use_updater (bool): האם לאפשר יצירת Updater (נדרש עבור מצב polling).
         """
         # התחברות ל-DB
         await db.connect()
         
         # יצירת application
-        self.application = Application.builder().token(TELEGRAM_BOT_TOKEN).build()
+        builder = Application.builder().token(TELEGRAM_BOT_TOKEN)
+
+        if not use_updater:
+            builder.updater(None)
+
+        self.application = builder.build()
         
         # רישום handlers
         self._register_handlers()
-        
-        logger.info("✅ הבוט הוגדר בהצלחה")
+
+        mode = "Webhook mode (Updater disabled)" if not use_updater else "Polling mode (Updater enabled)"
+        logger.info("✅ הבוט הוגדר בהצלחה (%s)", mode)
     
     def _register_handlers(self):
         """

--- a/main.py
+++ b/main.py
@@ -133,7 +133,7 @@ async def setup_webhook() -> bool:
     webhook_url = f"{RENDER_EXTERNAL_URL.rstrip('/')}/{TELEGRAM_BOT_TOKEN}"
 
     try:
-        await bot.setup()
+        await bot.setup(use_updater=False)
 
         # ניקוי webhook קיים
         await bot.application.bot.delete_webhook(drop_pending_updates=True)
@@ -192,7 +192,7 @@ def run_polling():
     """
 
     async def main():
-        await bot.setup()
+        await bot.setup(use_updater=True)
 
         # הפעלת polling
         await bot.application.initialize()


### PR DESCRIPTION
Disable `Updater` instantiation in webhook mode to resolve `AttributeError` with Python 3.13 and `python-telegram-bot`.

The `AttributeError: 'Updater' object has no attribute '_Updater__polling_cleanup_cb'` occurred during deployment on Render due to an incompatibility between Python 3.13 and the `Updater` class in `python-telegram-bot`. By explicitly setting `updater(None)` when building the `Application` in webhook mode, we prevent the `Updater` from being instantiated, thus avoiding the error. This change ensures the bot can deploy successfully in webhook mode while maintaining functionality for local polling.

---
<a href="https://cursor.com/background-agent?bcId=bc-61110774-2aeb-4cf8-af1b-1f854de1a8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61110774-2aeb-4cf8-af1b-1f854de1a8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

