### PR TITLE
Fix flask before_first_request attribute error

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,10 +28,10 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 
 
-@app.before_first_request
-def _initialize_bot_on_first_request() -> None:
+@app.before_serving
+def _initialize_bot_before_serving() -> None:
     """
-    מבטיחים שהבוט יאותחל לאחר יצירת ה-worker של Gunicorn.
+    מבטיחים שהבוט יאותחל לאחר יצירת ה-worker של Gunicorn ולפני קבלת בקשות.
     """
     if not (RENDER_EXTERNAL_URL and TELEGRAM_BOT_TOKEN):
         return


### PR DESCRIPTION
Replace `app.before_first_request` with `app.before_serving` to resolve an `AttributeError` in Flask 3.

---
<a href="https://cursor.com/background-agent?bcId=bc-65a6f5ae-a9b7-47a6-843a-76e3b3e0683a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-65a6f5ae-a9b7-47a6-843a-76e3b3e0683a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

