### PR TITLE
Fix flask before_serving attribute error

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,11 +28,13 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 
 
-@app.before_serving
-def _initialize_bot_before_serving() -> None:
+@app.before_request
+def _initialize_bot_before_request() -> None:
     """
-    מבטיחים שהבוט יאותחל לאחר יצירת ה-worker של Gunicorn ולפני קבלת בקשות.
+    מבטיחים שהבוט יאותחל לאחר יצירת ה-worker של Gunicorn ולפני עיבוד בקשות.
     """
+    if _bot_initialized.is_set():
+        return
     if not (RENDER_EXTERNAL_URL and TELEGRAM_BOT_TOKEN):
         return
 


### PR DESCRIPTION
Replace `app.before_serving` with a guarded `app.before_request` to fix `AttributeError` in Flask 3.0.

`app.before_serving` was removed in Flask 3.0, causing an `AttributeError`. This change replaces it with `app.before_request` and adds a check to ensure the bot initialization logic runs only once per Gunicorn worker, preserving the original intent of initializing the bot before handling requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-e98b1689-8c98-4e03-bf99-e1bad5cc5fc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e98b1689-8c98-4e03-bf99-e1bad5cc5fc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

